### PR TITLE
Fix run_ behavior

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -1064,7 +1064,7 @@ command1_ com args one_arg more_args = run_ com (args ++ [one_arg] ++ more_args)
 run_ :: FilePath -> [Text] -> Sh ()
 run_ exe args =
   -- same a runFoldLines except Inherit Stdout
-  runHandles exe args [OutHandle Inherit] $ \inH _ errH -> do
+  runHandles exe args [] $ \inH _ errH -> do
     state <- get
     errVar <- liftIO $ do
       hClose inH -- setStdin was taken care of before the process even ran

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -1063,7 +1063,7 @@ command1_ com args one_arg more_args = run_ com (args ++ [one_arg] ++ more_args)
 -- stdout will be read and discarded line-by-line
 run_ :: FilePath -> [Text] -> Sh ()
 run_ exe args =
-  -- same a runFoldLines except Inherit Stdout
+  -- same a runFoldLines except ignore outH
   runHandles exe args [] $ \inH _ errH -> do
     state <- get
     errVar <- liftIO $ do


### PR DESCRIPTION
The implementation of `run_` ignores the `silently` combinator. For example:

```haskell
{-# LANGUAGE OverloadedStrings #-}
import Data.Text
import Shelly
main = (shelly . silently) $ do
    run "echo" ["run: this should not be printed"]
    run_ "echo" ["run_: this should not be printed"]
```

I think this "leakage" is caused by run_ inheriting the stdout handle. Only `runFoldLines` seems to respect the value of `sPrintStdout`. I don't think this change will break any of the combinators that rely on `run_`.

