### PR TITLE
Allow exceptions > 0.6 in test suite

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -110,7 +110,7 @@ Test-Suite shelly-testsuite
     lifted-base,
     lifted-async,
     enclosed-exceptions,
-    exceptions                == 0.6.*
+    exceptions
 
   extensions:
     CPP


### PR DESCRIPTION
Necessary for Stackage builds