### PR TITLE
[Review & Discuss] Preliminar version of bash and bash_

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -1058,7 +1058,9 @@ bash fp args = escaping False $ do
   run "bash" ["-c", "'set -o pipefail && " <> sanitise (toTextIgnore fp : args) <> "'"]
 
 bash_ :: FilePath -> [Text] -> Sh ()
-bash_ fp args = const () <$> bash fp args
+bash_ fp args = escaping False $ do
+  let sanitise = T.replace "'" "\'" . T.intercalate " "
+  run_ "bash" ["-c", "'set -o pipefail && " <> sanitise (toTextIgnore fp : args) <> "'"]
 
 -- | bind some arguments to run for re-use. Example:
 --

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -30,7 +30,7 @@ module Shelly
          , log_stdout_with, log_stderr_with
 
          -- * Running external commands.
-         , run, run_, runFoldLines, cmd, FoldCallback
+         , run, run_, bash, bash_, runFoldLines, cmd, FoldCallback
          , (-|-), lastStderr, setStdin, lastExitCode
          , command, command_, command1, command1_
          , sshPairs, sshPairs_
@@ -1049,6 +1049,16 @@ instance Exception e => Show (ReThrownException e) where
 --
 run :: FilePath -> [Text] -> Sh Text
 run fp args = return . lineSeqToText =<< runFoldLines mempty (|>) fp args
+
+-- | Like `run`, but it invokes the user-requested program with _bash_,
+-- setting _pipefail_ appropriately.
+bash :: FilePath -> [Text] -> Sh Text
+bash fp args = escaping False $ do
+  let sanitise = T.replace "'" "\'" . T.intercalate " "
+  run "bash" ["-c", "'set -o pipefail && " <> sanitise (toTextIgnore fp : args) <> "'"]
+
+bash_ :: FilePath -> [Text] -> Sh ()
+bash_ fp args = const () <$> bash fp args
 
 -- | bind some arguments to run for re-use. Example:
 --

--- a/test/src/RunSpec.hs
+++ b/test/src/RunSpec.hs
@@ -24,3 +24,32 @@ runSpec = do
       res <- shelly $ onCommandHandles (initOutputHandles (flip hSetBinaryMode True))
                     $ run "cat" [ "test/data/nonascii.txt" ]
       res @?= "Selbstverst\228ndlich \252berraschend\n"
+
+  -- Bash-related commands
+  describe "bash" $ do
+    it "simple command" $ do
+      res <- shelly $ bash "echo" [ "wibble" ]
+      res @?= "wibble\n"
+
+    it "without escaping" $ do
+      res <- shelly $ escaping False $ bash "echo" [ "*" ]
+      assert $ "README.md" `elem` T.words res
+
+    it "with binary handle mode" $ do
+      res <- shelly $ onCommandHandles (initOutputHandles (flip hSetBinaryMode True))
+                    $ bash "cat" [ "test/data/nonascii.txt" ]
+      res @?= "Selbstverst\228ndlich \252berraschend\n"
+
+    it "can detect failing commands in pipes" $ do
+      eCode <- shelly $ escaping False $ errExit False $ do
+        bash_ "echo" [ "'foo'", "|", "ls", "\"eoueouoe\"", "|", "echo", "'bar'" ]
+        lastExitCode
+      eCode @?= 1
+
+    it "preserve pipe behaviour" $ do
+      (eCode, res) <- shelly $ escaping False $ errExit False $ do
+        res <- bash "echo" [ "'foo'", "|", "echo", "'bar'" ]
+        eCode <- lastExitCode
+        return (eCode, res)
+      res @?= "bar\n"
+      eCode @?= 0

--- a/test/src/TestMain.hs
+++ b/test/src/TestMain.hs
@@ -28,4 +28,3 @@ main = hspec $ do
     copySpec
     liftedSpec
     runSpec
-


### PR DESCRIPTION
Hey Greg,

this is a first naive attempt to create `bash` and `bash_`. A couple of comments:

* They internally uses `escaping False` as it's required for the `&&` and such
   - We should probably add a note in the function documentation.
* I suspect `bash_` to be memory inefficient as it does not discard line by line the stdout, can we make it such without boilerplate? (i.e. piggybacking on some internal functions?)
* Tests are there but are quite barebone. I didn't go overboard in testing those.

Immediate thoughts?