### PR TITLE
Add prependToPath function.

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -45,7 +45,7 @@ module Shelly
          , HandleInitializer, StdInit(..), initOutputHandles, initAllHandles
 
          -- * Modifying and querying environment.
-         , setenv, get_env, get_env_text, getenv, get_env_def, get_env_all, get_environment, appendToPath
+         , setenv, get_env, get_env_text, getenv, get_env_def, get_env_all, get_environment, appendToPath, prependToPath
 
          -- * Environment directory
          , cd, chdir, chdir_p, pwd
@@ -749,6 +749,13 @@ appendToPath = traceAbsPath ("appendToPath: " <>) >=> \filepath -> do
   tp <- toTextWarn filepath
   pe <- get_env_text path_env
   setPath $ pe <> T.singleton searchPathSeparator <> tp
+
+-- | like `appendToPath` but add the given `FilePath` at the front of the PATH env variable.
+prependToPath :: FilePath -> Sh ()
+prependToPath = traceAbsPath ("prependToPath: " <>) >=> \filepath -> do
+  tp <- toTextWarn filepath
+  pe <- get_env_text path_env
+  setPath $ tp <> T.singleton searchPathSeparator <> pe
 
 get_environment :: Sh [(String, String)]
 get_environment = gets sEnvironment

--- a/src/Shelly/Lifted.hs
+++ b/src/Shelly/Lifted.hs
@@ -51,7 +51,7 @@ module Shelly.Lifted
 
 
          -- * Modifying and querying environment.
-         , setenv, get_env, get_env_text, get_env_all, appendToPath
+         , setenv, get_env, get_env_text, get_env_all, appendToPath, prependToPath
 
          -- * Environment directory
          , cd, chdir, chdir_p, pwd
@@ -458,6 +458,9 @@ setenv = (liftSh .) . S.setenv
 
 appendToPath :: MonadSh m => FilePath -> m ()
 appendToPath = liftSh . S.appendToPath
+
+prependToPath :: MonadSh m => FilePath -> m ()
+prependToPath = liftSh . S.prependToPath
 
 get_env_all :: MonadSh m => m [(String, String)]
 get_env_all = liftSh S.get_env_all

--- a/src/Shelly/Pipe.hs
+++ b/src/Shelly/Pipe.hs
@@ -45,9 +45,9 @@ module Shelly.Pipe
          , (-|-), lastStderr, setStdin, lastExitCode
          , command, command_, command1, command1_
          , sshPairs, sshPairs_
- 
+
          -- * Modifying and querying environment.
-         , setenv, get_env, get_env_text, get_env_def, appendToPath
+         , setenv, get_env, get_env_text, get_env_def, appendToPath, prependToPath
 
          -- * Environment directory
          , cd, chdir, pwd
@@ -338,6 +338,10 @@ get_env_def a d = sh0 $ fmap (fromMaybe d) $ S.get_env a
 -- | see 'S.appendToPath'
 appendToPath :: FilePath -> Sh ()
 appendToPath = sh1 S.appendToPath
+
+-- | see 'S.prependToPath'
+prependToPath :: FilePath -> Sh ()
+prependToPath = sh1 S.prependToPath
 
 -- | see 'S.cd'
 cd :: FilePath -> Sh ()


### PR DESCRIPTION
Hey @gregwebs !

I have added a `prependToPath` function I recently had the need for.

The main use case is for when you want your added path to take precedence over something else which contain the executable you want to invoke.

Do you think it makes sense?

Bye!

Alfredo