### PR TITLE
Added followSymlink for find-command

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -27,6 +27,7 @@ module Shelly
          , silently, verbosely, escaping, print_stdout, print_stderr, print_commands
          , onCommandHandles
          , tracing, errExit
+         , followSymlink
          , log_stdout_with, log_stderr_with
 
          -- * Running external commands.
@@ -905,6 +906,15 @@ errExit shouldExit action = sub $ do
   modify $ \st -> st { sErrExit = shouldExit }
   action
 
+-- | 'find'-command follows symbolic links. Defaults to @False@.
+-- When @True@, follow symbolic links.
+-- When @False@, never follow symbolic links.
+followSymlink :: Bool -> Sh a -> Sh a
+followSymlink enableFollowSymlink action = sub $ do
+  modify $ \st -> st { sFollowSymlink = enableFollowSymlink }
+  action
+
+
 defReadOnlyState :: ReadOnlyState
 defReadOnlyState = ReadOnlyState { rosFailToDir = False }
 
@@ -948,6 +958,7 @@ shelly' ros action = do
                    , sPathExecutables = Nothing
                    , sErrExit = True
                    , sReadOnly = ros
+                   , sFollowSymlink = False
                    }
   stref <- liftIO $ newIORef def
   let caught =

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -27,7 +27,6 @@ module Shelly
          , silently, verbosely, escaping, print_stdout, print_stderr, print_commands
          , onCommandHandles
          , tracing, errExit
-         , followSymlink
          , log_stdout_with, log_stderr_with
 
          -- * Running external commands.
@@ -90,6 +89,7 @@ module Shelly
 
          -- * find functions
          , find, findWhen, findFold, findDirFilter, findDirFilterWhen, findFoldDirFilter
+         , followSymlink
          ) where
 
 import Shelly.Base

--- a/src/Shelly/Base.hs
+++ b/src/Shelly/Base.hs
@@ -125,6 +125,7 @@ data State = State
    , sTrace :: Text -- ^ the trace of command execution
    , sErrExit :: Bool -- ^ should we exit immediately on any error
    , sReadOnly :: ReadOnlyState
+   , sFollowSymlink :: Bool -- ^ 'find'-command follows symlinks.
    }
 
 data StdHandle = InHandle StdStream

--- a/src/Shelly/Find.hs
+++ b/src/Shelly/Find.hs
@@ -69,7 +69,8 @@ findFoldDirFilter folder startValue dirFilter dir = do
       isDir <- liftIO $ isDirectory absolutePath
       sym   <- liftIO $ fmap isSymbolicLink $ getSymbolicLinkStatus (encodeString absolutePath)
       newAcc <- folder acc relativePath
-      if isDir && not sym
+      follow <- fmap sFollowSymlink get
+      if isDir && (follow || not sym)
         then findFoldDirFilter folder newAcc 
                 dirFilter relativePath
         else return newAcc

--- a/src/Shelly/Lifted.hs
+++ b/src/Shelly/Lifted.hs
@@ -93,6 +93,7 @@ module Shelly.Lifted
 
          -- * find functions
          , S.find, S.findWhen, S.findFold, S.findDirFilter, S.findDirFilterWhen, S.findFoldDirFilter
+         , followSymlink
          ) where
 
 import qualified Shelly as S
@@ -344,6 +345,9 @@ escaping shouldEscape action = controlSh $ \runInSh -> S.escaping shouldEscape (
 
 errExit :: MonadShControl m => Bool -> m a -> m a
 errExit shouldExit action = controlSh $ \runInSh -> S.errExit shouldExit (runInSh action)
+
+followSymlink :: MonadShControl m => Bool -> m a -> m a
+followSymlink enableFollowSymlink action = controlSh $ \runInSh -> S.followSymlink enableFollowSymlink (runInSh action)
 
 (-|-) :: (MonadShControl m, MonadSh m) => m Text -> m b -> m b
 one -|- two = controlSh $ \runInSh -> do

--- a/src/Shelly/Pipe.hs
+++ b/src/Shelly/Pipe.hs
@@ -92,6 +92,7 @@ module Shelly.Pipe
          -- * find functions 
          , find, findWhen, findFold
          , findDirFilter, findDirFilterWhen, findFoldDirFilter
+         , followSymlink
          ) where
 
 import Prelude hiding (FilePath)
@@ -264,6 +265,9 @@ tracing b = lift1 (S.tracing b)
 errExit :: Bool -> Sh a -> Sh a
 errExit b = lift1 (S.errExit b)
 
+-- | see 'S.followSymlink'
+followSymlink :: Bool -> Sh a -> Sh a
+followSymlink b = lift1 (S.followSymlink b)
 
 -- | see 'S.run'
 run :: FilePath -> [Text] -> Sh Text

--- a/test/data/dir/symlinked_dir
+++ b/test/data/dir/symlinked_dir
@@ -1,0 +1,1 @@
+../symlinked_dir/

--- a/test/src/FindSpec.hs
+++ b/test/src/FindSpec.hs
@@ -67,3 +67,13 @@ findSpec = do
                     "ReadFileSpec.hs", "RmSpec.hs", "RunSpec.hs",
                     "TestInit.hs", "TestMain.hs",
                     "WhichSpec.hs", "WriteSpec.hs", "sleep.hs"]
+
+    it "follow symlinks" $ do
+      res <- shelly $ followSymlink True $ relPath "test/data" >>= find >>= mapM (relativeTo "test/data")
+      sort res @?=  ["dir","nonascii.txt","symlinked_dir","zshrc","dir/symlinked_dir",
+                     "dir/symlinked_dir/hoge_file","symlinked_dir/hoge_file"]
+
+    it "not follow symlinks" $ do
+      res <- shelly $ followSymlink False $ relPath "test/data" >>= find >>= mapM (relativeTo "test/data")
+      sort res @?=  ["dir","nonascii.txt","symlinked_dir","zshrc","dir/symlinked_dir",
+                     "symlinked_dir/hoge_file"]


### PR DESCRIPTION
Hi,

Currently, find-command can not follow symlink like 'find -L'.
See this [code](https://github.com/yesodweb/Shelly.hs/blob/master/src/Shelly/Find.hs#L72).
This PR adds ```followSymlink```-flag to follow symlinks.
