### PR TITLE
Support for Stackage nightly-2017-07-31 (GHC8.2.1)

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -1,6 +1,6 @@
 Name:       shelly
 
-Version:     1.6.8.3
+Version:     1.6.8.4
 Synopsis:    shell-like (systems) programming in Haskell
 
 Description: Shelly provides convenient systems programming in Haskell,
@@ -48,7 +48,7 @@ Library
 
   Build-depends:
     containers                >= 0.4.2.0,
-    time                      >= 1.3 && < 1.7,
+    time                      >= 1.3 && < 1.9,
     directory                 >= 1.1.0.0 && < 1.4.0.0,
     mtl                       >= 2,
     process                   >= 1.0,
@@ -128,7 +128,7 @@ Test-Suite shelly-testsuite
     unix-compat               < 0.5,
     system-filepath           >= 0.4.7 && < 0.5,
     system-fileio             < 0.4,
-    time                      >= 1.3 && < 1.7,
+    time                      >= 1.3 && < 1.9,
     mtl                       >= 2,
     HUnit                     >= 1.2,
     hspec                     >= 1.5,


### PR DESCRIPTION
This version bump is due to trying to build "regex" library on the latest Stackage nightly.
If you approve this pull request, please upload it then on Hackage so we could try to build other dependencies with it.