### PR TITLE
Fix constructor for process 1.5.0

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -363,6 +363,9 @@ shellyProcess reusedHandles st cmdSpec =  do
         , child_group = Nothing
         , child_user = Nothing
 #endif
+#if MIN_VERSION_process(1,5,0)
+        , use_process_jobs = False
+#endif
         }
     return ( just $ createdInH <|> toHandle mInH
            , just $ createdOutH <|> toHandle mOutH


### PR DESCRIPTION
Raise exception using `nightly-2017-10-13` on Windows 10

```
Exception: src\Shelly.hs:(343,72)-(366,9): Missing field in record construction use_process_jobs
```

Cause is constructor of [`CreateProcess`](https://hackage.haskell.org/package/process-1.6.1.0/docs/System-Process.html#t:CreateProcess) type.
This constructor added record fieald since 1.5.0.

So, fixed this.