### PR TITLE
fixed copying symbolic links via "-R" option. "-r" is deprecated.

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -1399,7 +1399,7 @@ cp_r from' to' = do
     from <- absPath from'
     fromIsDir <- (test_d from)
     if not fromIsDir then cp from' to' else do
-       trace $ "cp -r " <> toTextIgnore from <> " " <> toTextIgnore to'
+       trace $ "cp -R " <> toTextIgnore from <> " " <> toTextIgnore to'
        to <- absPath to'
        toIsDir <- test_d to
 


### PR DESCRIPTION
from "man cp":
This option also causes symbolic links to be copied, rather than indirected through, and for cp to create special files rather than copying them as normal files. Created directories have the same mode as the corresponding source directory, unmodified by the process' umask.
COMPATIBILITY
Historic versions of the cp utility had a -r option. This implementation supports that option; however, its use is strongly discouraged, as it does not correctly copy special files, symbolic links, or fifo's.