### PR TITLE
Drop depedency system-fileio and system-filepath

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -13,7 +13,7 @@ Description: Shelly provides convenient systems programming in Haskell,
              .
                * maintains its own environment, making it thread-safe.
              .
-               * is modern, using Text and system-filepath/system-fileio
+               * is modern, using Text filepath/directory
              .
              Shelly is originally forked from the Shellish package.
              .
@@ -55,8 +55,7 @@ Library
     process                   >= 1.0,
     unix-compat               < 0.6,
     unix,
-    system-filepath           >= 0.4.7 && < 0.5,
-    system-fileio             < 0.4,
+    filepath,
     monad-control             >= 0.3.2 && < 1.1,
     lifted-base,
     lifted-async,
@@ -130,8 +129,6 @@ Test-Suite shelly-testsuite
     process                   >= 1.1.0,
     unix-compat               < 0.6,
     unix,
-    system-filepath           >= 0.4.7 && < 0.5,
-    system-fileio             < 0.4,
     time                      >= 1.3 && < 1.9,
     mtl                       >= 2,
     HUnit                     >= 1.2,

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -526,6 +526,7 @@ mv from' to' = do
         ReThrownException e (extraMsg to_loc from)
       )
   where
+    extraMsg :: String -> String -> String
     extraMsg t f = "during copy from: " ++ f ++ " to: " ++ t
 
 -- | Get back [Text] instead of [FilePath]
@@ -1441,6 +1442,7 @@ cp_should_follow_symlinks shouldFollowSymlinks from' to' = do
       target <- liftIO $ getSymbolicLinkTarget from
       liftIO $ createFileLink target to_loc
   where
+    extraMsg :: String -> String -> String
     extraMsg t f = "during copy from: " ++ f ++ " to: " ++ t
     copyNormal from to = liftIO $ copyFile from to `catchany` (\e -> throwIO $
           ReThrownException e (extraMsg to from)

--- a/src/Shelly/Directory.hs
+++ b/src/Shelly/Directory.hs
@@ -2,7 +2,7 @@
 module Shelly.Directory where
 
 import System.IO.Error (modifyIOError, ioeSetLocation, ioeGetLocation)
-import qualified Filesystem.Path.CurrentOS as FP
+import qualified System.Directory as FP
 
 #ifdef mingw32_HOST_OS
 import qualified System.Win32 as Win32

--- a/src/Shelly/Lifted.hs
+++ b/src/Shelly/Lifted.hs
@@ -80,7 +80,7 @@ module Shelly.Lifted
          , bracket_sh, catchany, catch_sh, handle_sh, handleany_sh, finally_sh, catches_sh, catchany_sh
 
          -- * convert between Text and FilePath
-         , S.toTextIgnore, toTextWarn, FP.fromText
+         , S.toTextIgnore, toTextWarn, S.fromText
 
          -- * Utility Functions
          , S.whenM, S.unlessM, time, sleep
@@ -105,7 +105,7 @@ import Data.ByteString ( ByteString )
 import Data.Monoid
 import System.IO ( Handle )
 import Data.Tree ( Tree )
-import qualified Filesystem.Path.CurrentOS as FP
+import qualified System.FilePath as FP
 
 import Control.Exception.Lifted
 import Control.Exception.Enclosed

--- a/src/Shelly/Pipe.hs
+++ b/src/Shelly/Pipe.hs
@@ -78,7 +78,7 @@ module Shelly.Pipe
          , catchany_sh
 
          -- * convert between Text and FilePath
-         , toTextIgnore, toTextWarn, fromText
+         , toTextIgnore, toTextWarn, S.fromText
 
          -- * Utilities.
          , (<$>), whenM, unlessM, time
@@ -102,14 +102,14 @@ import Control.Monad
 import Control.Monad.Trans
 import Control.Exception hiding (handle)
 
-import Filesystem.Path(FilePath)
+import System.FilePath(FilePath)
 
 import qualified Shelly as S
 
 import Shelly(
       (</>), (<.>), hasExt
     , whenM, unlessM, toTextIgnore
-    , fromText, catchany
+    , catchany
     , FoldCallback)
 
 import Data.Maybe(fromMaybe)

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,6 @@ flags: {}
 packages:
 - '.'
 - shelly-extra/
-resolver: lts-8.3
+resolver: lts-12.26
 extra-deps:
   - SafeSemaphore-0.10.1

--- a/test/src/FindSpec.hs
+++ b/test/src/FindSpec.hs
@@ -5,10 +5,11 @@ import Data.List (sort)
 import System.Directory (createDirectoryIfMissing)
 import System.PosixCompat.Files (createSymbolicLink, fileExist)
 import qualified System.FilePath as SF
+import Shelly
 
 createSymlinkForTest :: IO ()
 createSymlinkForTest = do
-  createDirectoryIfMissing False symDir
+  createDirectoryIfMissing True symDir
   fexist <- fileExist (symDir SF.</> "symlinked_dir")
   if fexist
     then return ()
@@ -48,6 +49,14 @@ findSpec = do
                     "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./SshSpec.hs",
                     "./TestInit.hs", "./TestMain.hs",
                     "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
+
+    it "lists relative files in folder" $ do
+      res <- shelly $ cd "test" >> ls "src"
+      sort res @?= ["src/CopySpec.hs", "src/EnvSpec.hs", "src/FailureSpec.hs",
+                    "src/FindSpec.hs", "src/Help.hs", "src/LiftedSpec.hs", "src/LogWithSpec.hs", "src/MoveSpec.hs",
+                    "src/ReadFileSpec.hs", "src/RmSpec.hs", "src/RunSpec.hs", "src/SshSpec.hs",
+                    "src/TestInit.hs", "src/TestMain.hs",
+                    "src/WhichSpec.hs", "src/WriteSpec.hs", "src/sleep.hs"]
 
     it "finds relative files" $ do
       res <- shelly $ cd "test/src" >> find "."
@@ -92,12 +101,12 @@ findSpec = do
               relPath "test/data" >>= find >>= mapM (relativeTo "test/data")
             sort res @?=
               [ "dir"
-              , "nonascii.txt"
-              , "symlinked_dir"
-              , "zshrc"
               , "dir/symlinked_dir"
               , "dir/symlinked_dir/hoge_file"
+              , "nonascii.txt"
+              , "symlinked_dir"
               , "symlinked_dir/hoge_file"
+              , "zshrc"
               ]
       it "not follow symlinks" $
          do res <-
@@ -106,10 +115,10 @@ findSpec = do
               relPath "test/data" >>= find >>= mapM (relativeTo "test/data")
             sort res @?=
               [ "dir"
+              , "dir/symlinked_dir"
               , "nonascii.txt"
               , "symlinked_dir"
-              , "zshrc"
-              , "dir/symlinked_dir"
               , "symlinked_dir/hoge_file"
+              , "zshrc"
               ]
 

--- a/test/src/RmSpec.hs
+++ b/test/src/RmSpec.hs
@@ -1,6 +1,7 @@
 module RmSpec (rmSpec) where
 
 import TestInit
+import Data.Text as T
 import Help
 
 rmSpec :: Spec
@@ -56,7 +57,7 @@ rmSpec = do
     it "rm" $ do
       res <- shelly $ do
         writefile b "b"
-        cmd "ln" "-s" b l
+        cmd "ln" "-s" (T.pack b) (T.pack l)
         rm l
         test_f b
       assert res
@@ -65,7 +66,7 @@ rmSpec = do
     it "rm_f" $ do
       res <- shelly $ do
         writefile b "b"
-        cmd "ln" "-s" b l
+        cmd "ln" "-s" (T.pack b) (T.pack l)
         rm_f l
         test_f b
       assert res
@@ -75,7 +76,7 @@ rmSpec = do
       res <- shelly $ do
         mkdir d
         writefile (d</>b) "b"
-        cmd "ln" "-s" (d</>b) l
+        cmd "ln" "-s" (T.pack $ d</>b) (T.pack l)
         rm_rf l
         test_f (d</>b)
       assert res


### PR DESCRIPTION
Closes #116 

Updates include:
* Update stack.yaml to lts-12.26
* Add a test case to be more clear what the expected output of `ls` should be
* Replace `system-filepath` with `filepath`
* Update tests to work with the new `FilePath` datatype

Quirks: 
`test/src/RmSpec.hs` shows that more type annotations are necessary when using `FilePath` as a command and program argument at the same time. 
Thus, I anticipate that some programs will break.